### PR TITLE
Gracefully Handle Empty Args to `{{w`

### DIFF
--- a/addon/helpers/w.js
+++ b/addon/helpers/w.js
@@ -4,7 +4,9 @@ import { w as toWords } from 'ember-string';
 export function w([...wordStrings]) {
   return wordStrings
     .map(toWords)
-    .reduce((words, moreWords) => words.concat(moreWords));
+    .reduce((words, moreWords) => {
+      return words.concat(moreWords);
+    }, []);
 }
 
 export default helper(w);

--- a/tests/integration/helpers/w-test.js
+++ b/tests/integration/helpers/w-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('join', 'Integration | Helper | {{join}}', {
+moduleForComponent('join', 'Integration | Helper | {{w}}', {
   integration: true
 });
 
@@ -21,4 +21,10 @@ test('It makes an array of many words', function(assert) {
 test('You can even break up multiple strings of words', function(assert) {
   this.render(hbs`{{#each (w "foo bar" "baz") as |word|}}{{word}}{{/each}}`);
   assert.equal(this.$().text().trim(), 'foobarbaz', 'the words are turned into an array');
+});
+
+test('It gracefully handles empty arguments', function(assert) {
+  this.render(hbs`{{#each (w) as |word|}}{{word}}{{/each}}`);
+
+  assert.equal(this.$().text().trim(), '', 'is blank');
 });


### PR DESCRIPTION
This also fixes the integration test suite name

Resolves #3 