### PR TITLE
Handle capitals in humanize helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Mark a string as safe for unescaped output with Ember templates using `Ember.Str
 **[⬆️ back to top](#available-helpers)**
 
 #### `humanize`
-Removes dashes and underscores from a string, and capitalizes the first letter.
+Removes dashes and underscores from a string, capitalizes the first letter and makes the rest of the string lower case.
 
 ```hbs
 {{humanize "some-string"}}

--- a/addon/helpers/humanize.js
+++ b/addon/helpers/humanize.js
@@ -9,7 +9,7 @@ export function humanize([string]) {
     return '';
   }
 
-  let result = string.replace(regex, replacement);
+  let result = string.toLowerCase().replace(regex, replacement);
   return result.charAt(0).toUpperCase() + result.slice(1);
 }
 

--- a/tests/integration/helpers/humanize-test.js
+++ b/tests/integration/helpers/humanize-test.js
@@ -44,3 +44,51 @@ test('It correctly handles undefined input', function(assert) {
 
   assert.equal(this.$().text().trim(), expected, 'converts underscored to humanized');
 });
+
+test('It correctly handles capitalised input with spaces', function(assert) {
+  this.render(hbs `{{humanize "CHOOSE AN ITEM COLOR"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});
+
+test('It correctly handles capitalised input with underscores', function(assert) {
+  this.render(hbs `{{humanize "CHOOSE_AN_ITEM_COLOR"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});
+
+test('It correctly handles capitalised input with dashes', function(assert) {
+  this.render(hbs `{{humanize "CHOOSE-AN-ITEM-COLOR"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});
+
+test('It correctly handles mixed-case input with spaces', function(assert) {
+  this.render(hbs `{{humanize "cHoOsE aN iTeM cOlOr"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});
+
+test('It correctly handles mixed-case input with underscores', function(assert) {
+  this.render(hbs `{{humanize "cHoOsE_aN_iTeM_cOlOr"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});
+
+test('It correctly handles mixed-case input with dashes', function(assert) {
+  this.render(hbs `{{humanize "cHoOsE-aN-iTeM-cOlOr"}}`);
+
+  let expected = 'Choose an item color';
+
+  assert.equal(this.$().text().trim(), expected, 'converts capitals to humanized');
+});


### PR DESCRIPTION
Passing uppercase strings to `humanize` returns an uppercase string, which is not the desired behaviour for a `humanize` function. This PR handles the situation by lowercasing the input string before applying the existing transformations.