### PR TITLE
Upgrade dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    browser: true
+  },
+  rules: {
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -14,4 +14,10 @@
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
+yarn-error.log
 testem.log
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@
 .editorconfig
 .ember-cli
 .gitignore
-.jshintrc
+.eslintrc.js
 .watchmanconfig
 .travis.yml
 bower.json

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "ember-cli-string-helpers",
-  "dependencies": {
-    "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3"
-  }
-}

--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,8 @@ machine:
     version: "stable"
 dependencies:
   pre:
-    - npm install -g bower
   post:
     - npm install
-    - bower install
 test:
   override:
     - npm test

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,78 +1,82 @@
-/*jshint node:true*/
-var command = [ 'ember', 'exam', '--split', '3', '--random' ];
-
+/* eslint-env node */
 module.exports = {
-  command: command.join(' '),
   scenarios: [
     {
-      name: 'ember-pre-2',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          "ember": "~1.13.0"
-        }
-      }
-    },
-    {
-      name: 'ember-2',
-      bower: {
-        dependencies: {
-          "ember": "~2.0.0"
-        }
-      }
-    },
-    {
-      name: 'ember-lts',
-      bower: {
-        dependencies: {
-          "ember": "~2.4.0"
-        }
-      }
-    },
-    {
-      name: 'ember-latest',
-      bower: {
-        dependencies: {
-          "ember": "release"
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          "ember": "release"
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.12.0'
+        }
+      }
+    },
+    {
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
       name: 'ember-beta',
-      allowedToFail: true,
       bower: {
         dependencies: {
-          "ember": "beta"
+          'ember': 'components/ember#beta'
         },
         resolutions: {
-          "ember": "beta"
+          'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
       name: 'ember-canary',
-      allowedToFail: true,
       bower: {
         dependencies: {
-          "ember": "canary"
+          'ember': 'components/ember#canary'
         },
         resolutions: {
-          "ember": "canary"
+          'ember': 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: 'ember-alpha',
-      allowedToFail: true,
-      bower: {
-        dependencies: {
-          "ember": "alpha"
-        },
-        resolutions: {
-          "ember": "alpha"
-        }
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,10 @@
-/*jshint node:true*/
-/* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   "repository": "https://github.com/romulomachado/ember-cli-string-helpers",
   "bugs": "https://github.com/romulomachado/ember-cli-string-helpers/issues",
   "homepage": "https://github.com/romulomachado/ember-cli-string-helpers",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
   "author": [
     "Lauren Tan <arr@sugarpirate.com>",
     "Marten Schilstra <mail@martenschilstra.nl>",
@@ -27,28 +24,31 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "chai": "^3.5.0",
-    "ember-ajax": "^2.4.1",
-    "ember-cli": "2.9.1",
+    "ember-ajax": "^3.0.0",
+    "ember-cli": "^2.15.1",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-eslint": "^4.0.0",
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-jshint": "^1.0.4",
-    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-qunit": "^4.0.0",
+    "ember-cli-shims": "^1.1.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-exam": "0.4.6",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~2.15.0",
+    "ember-welcome-page": "^3.0.0",
     "ember-sinon": "0.5.0",
-    "ember-suave": "4.0.0",
-    "loader.js": "^4.0.10",
+    "ember-suave": "4.0.1",
+    "loader.js": "^4.2.3",
     "mocha": "^2.4.5"
   },
   "keywords": [
@@ -57,7 +57,10 @@
   ],
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.3.0"
+  },
+  "engines": {
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.js
+++ b/testem.js
@@ -1,13 +1,19 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "parallel": "-1",
-  "launch_in_ci": [
-    "Chrome"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: [
+      '--disable-gpu',
+      '--headless',
+      '--remote-debugging-port=9222',
+      '--window-size=1440,900'
+    ]
+  }
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+};

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,15 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const { Application: EmberApplication } = Ember;
-
-let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = EmberApplication.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,8 +9,8 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,5 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
-
-const { Router: EmberRouter } = Ember;
 
 const Router = EmberRouter.extend({
   location: config.locationType,

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,10 @@
-/* jshint node: true */
+/* eslint-env node */
+'use strict';
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
-    environment: environment,
+    environment,
     rootURL: '/',
     locationType: 'auto',
     EmberENV: {

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { run } = Ember;
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -17,7 +17,7 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach(...arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,26 +1,16 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 
-const {
-  assign: emberAssign,
-  merge: emberMerge,
-  run
-} = Ember;
-
-const assign = emberAssign || emberMerge;
-
 export default function startApp(attrs) {
-  let application;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  let attributes = assign({}, config.APP);
-  attributes = assign(attributes, attrs); // use defaults, but you can override;
-
-  run(() => {
-    application = Application.create(attributes);
+  return run(() => {
+    let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
+    return application;
   });
-
-  return application;
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,7 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
+start();


### PR DESCRIPTION
updates the addon to the latest dependencies via ember init.

Addons that still depend on ember-cli-babel 5.x have build problems when a parent directory has a .babelrc file. Using ember-cli-babel 6.x fixes this issue and that was my primary goal in upgrading the dependencies for this add-on. 