### PR TITLE
Fix Node.js 4.x compatibility

### DIFF
--- a/lib/difference.js
+++ b/lib/difference.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+'use strict';
+
 /**
  * Finds the difference between 2 arrays.
  *

--- a/lib/intersection.js
+++ b/lib/intersection.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+'use strict';
+
 /**
  * Finds the intersection between 2 arrays.
  *


### PR DESCRIPTION
no issue
- files in `lib/` are imported within `index.js` which runs directly in Node.js, they were using `let` without specifying strict mode which throws an error in Node 4.x
- added `'use strict';` to `lib/difference.js` and `lib/intersection.js` so that the addon works again when using Node 4.x