### PR TITLE
Allow using ellipsis in truncate to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Truncates a string with a characterLimit and optionally adds an ellipsis to the 
 
 ```hbs
 {{truncate "Lorem ipsum dolor sit amet, consectetur adipiscing elit." 20 true}}
-{{truncate phrase useEllipsis}}
+{{truncate phrase characterLimit useEllipsis}}
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Trim a string.
 ```
 
 #### `truncate`
-Truncates a string with a characterLimit.
+Truncates a string with a characterLimit and optionally adds an ellipsis to the end.
 
 ```hbs
-{{truncate "Lorem ipsum dolor sit amet, consectetur adipiscing elit." 20}}
-{{truncate phrase}}
+{{truncate "Lorem ipsum dolor sit amet, consectetur adipiscing elit." 20 true}}
+{{truncate phrase useEllipsis}}
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/truncate.js
+++ b/addon/helpers/truncate.js
@@ -1,10 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export function truncate([string, characterLimit = 140]) {
-  let limit = characterLimit - 3;
+export function truncate([string, characterLimit = 140, useEllipsis = true]) {
+  let limit = useEllipsis ? characterLimit - 3 : characterLimit;
 
   if (string && string.length > limit) {
-    return `${string.substring(0, limit)}...`;
+    return useEllipsis ? `${string.substring(0, limit)}...` : string.substring(0, limit);
   } else {
     return string;
   }

--- a/tests/integration/helpers/truncate-test.js
+++ b/tests/integration/helpers/truncate-test.js
@@ -28,3 +28,12 @@ test('It does not truncate if string is not longer than characterLimit', functio
 
   assert.equal(this.$().text().trim(), expected, 'does not truncate');
 });
+
+test('It truncates to characterLimit provided without an ellipsis if useEllipsis is false', function(assert) {
+  this.render(hbs`{{truncate "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas hendrerit quam enim, in suscipit est rutrum id. Etiam vitae blandit purus, sed semper sem." 20 false}}`);
+
+  let expected = 'Lorem ipsum dolor si';
+
+  assert.equal(this.$().text().trim(), expected, 'truncates to characterLimit');
+});
+

--- a/tests/integration/helpers/truncate-test.js
+++ b/tests/integration/helpers/truncate-test.js
@@ -34,6 +34,6 @@ test('It truncates to characterLimit provided without an ellipsis if useEllipsis
 
   let expected = 'Lorem ipsum dolor si';
 
-  assert.equal(this.$().text().trim(), expected, 'truncates to characterLimit');
+  assert.equal(this.$().text().trim(), expected, 'truncates to characterLimit without ellipsis');
 });
 


### PR DESCRIPTION
Currently the truncate helper always uses an ellipsis so it will only shorten the string if after adding the ellipsis the string is still shorter, which leads to confusion as in #11.

## Changes proposed in this pull request
This closes #11 by adding an option to configure weather the truncate helper should use an ellipsis or not. This is set to `true` by default for backwards compatibility. 
<!-- Please describe here what this pull request changes -->
