### PR TITLE
Fix filter helpers regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ module.exports = {
   treeForAddon: function() {
     // see: https://github.com/ember-cli/ember-cli/issues/4463
     var tree = this._super.treeForAddon.apply(this, arguments);
+    var moduleRegexp = '(^modules\/)?' + this.name + '\/helpers\/';
 
-    return this.filterHelpers(tree, new RegExp('^modules/' + this.name + '/helpers/', 'i'));
+    return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
   },
 
   filterHelpers: function(tree, regex) {


### PR DESCRIPTION
After ember-cli v2.13, module's name is resolved without the `modules/` prefix.
This change allows for it to match both the old and new style.

Similar issue here: https://github.com/DockYard/ember-composable-helpers/issues/272