### PR TITLE
Move build options from `config/environment.js` to `ember-cli-build.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ ember install ember-cli-string-helpers
 
 ## Configuration
 
-If you don't need all the helpers, you can specify which to whitelist or blacklist using `only` or `except` within your `config/environment.js`:
+If you don't need all the helpers, you can specify which to whitelist or blacklist using `only` or `except` within your `ember-cli-build.js`:
 
 ```js
-module.exports = function(environment) {
-  var ENV = {
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
     'ember-cli-string-helpers': {
       only: ['dasherize', 'underscore'],
       except: ['titleize', 'capitalize']
     }
-  };
+  });
+};
 ```
 
 Both `only` and `except` can be safely used together (the addon computes the diff), although it's best if you only use one for your own sanity.

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ module.exports = {
       app = app.app;
     }
 
-    var config = app.project.config(app.env) || {};
-    var addonConfig = config[this.name] || {};
+    var addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
+    var addonConfig = addonOptions[this.name] || {};
+
     this.whitelist = this.generateWhitelist(addonConfig);
     this.blacklist = this.generateBlacklist(addonConfig);
   },


### PR DESCRIPTION
## Changes proposed in this pull request
This PR moves the build configuration from `config/environment.js` to `ember-cli-build.js`, following other addons structure.

Also updates the docs to reflect this.
