### PR TITLE
Added includes helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ only: ['camelize'] // imports only `camelize`
 * [`dasherize`](#dasherize)
 * [`html-safe`](#html-safe)
 * [`humanize`](#humanize)
+* [`includes`](#includes)
 * [`lowercase`](#lowercase)
 * [`titleize`](#titleize)
 * [`trim`](#trim)
@@ -105,6 +106,17 @@ Removes dashes and underscores from a string, capitalizes the first letter and m
 ```hbs
 {{humanize "some-string"}}
 {{humanize phrase}}
+```
+
+**[⬆️ back to top](#available-helpers)**
+
+#### `includes`
+Check whether a phrase contains a substring. The phrase can also be a string array.
+
+```hbs
+{{includes "some" "this is some string right here"}}
+{{includes "some" (array "this" "is" "some" "string" "right" "here")}}
+{{includes string phrase}}
 ```
 
 **[⬆️ back to top](#available-helpers)**

--- a/addon/helpers/includes.js
+++ b/addon/helpers/includes.js
@@ -1,0 +1,15 @@
+import { helper } from "@ember/component/helper";
+import { isHTMLSafe } from "@ember/string";
+
+export function includes([string, phrase]) {
+  if (isHTMLSafe(string)) {
+    string = string.string;
+  }
+  if (isHTMLSafe(phrase)) {
+    phrase = phrase.string;
+  }
+
+  return phrase.indexOf(string) !== -1;
+}
+
+export default helper(includes);

--- a/app/helpers/includes.js
+++ b/app/helpers/includes.js
@@ -1,0 +1,1 @@
+export { default, includes } from "ember-cli-string-helpers/helpers/includes";

--- a/tests/integration/helpers/includes-test.js
+++ b/tests/integration/helpers/includes-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { htmlSafe } from '@ember/string';
+
+module('Integration | Helper | {{includes}}', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // it handles safestrings for both params
+  // it handles an array for the phrase
+  // it includes is true
+  // it includes is false
+
+  test('It returns the correct value when the phrase is a string', async function(assert) {
+    await render(
+      hbs`{{includes "elit" "Lorem ipsum dolor sit amet, consectetur adipiscing elit."}}`
+    );
+
+    let expected = 'true';
+
+    assert.dom('*').hasText(expected, 'correct value when phrase is a string');
+  });
+
+  test('It returns the correct value when the phrase is a string array', async function(assert) {
+    this.set('string', 'dolor');
+    this.set('phrase', ["Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit."]);
+    await render(
+      hbs`{{includes "dolor" phrase}}`
+    );
+
+    let expected = 'true';
+
+    assert.dom('*').hasText(expected, 'correct value when phrase is a string array');
+  });
+
+  test('It returns the correct value when the string is not in the phrase', async function(assert) {
+    await render(
+      hbs`{{includes "notlatin" "Lorem ipsum dolor sit amet, consectetur adipiscing elit."}}`
+    );
+
+    let expected = 'false';
+
+    assert.dom('*').hasText(expected, 'correct value when string is not in the phrase');
+  });
+
+  test('It handles a SafeString for both parameters', async function(assert) {
+    this.set('string', htmlSafe('amet'));
+    this.set('phrase', htmlSafe('Lorem ipsum dolor sit amet, consectetur adipiscing elit.'));
+
+    await render(hbs`{{includes string phrase}}`);
+
+    let expected = 'true';
+
+    assert.dom('*').hasText(expected, 'correctly handles SafeStrings');
+  });
+});

--- a/tests/integration/helpers/includes-test.js
+++ b/tests/integration/helpers/includes-test.js
@@ -7,11 +7,6 @@ import { htmlSafe } from '@ember/string';
 module('Integration | Helper | {{includes}}', function(hooks) {
   setupRenderingTest(hooks);
 
-  // it handles safestrings for both params
-  // it handles an array for the phrase
-  // it includes is true
-  // it includes is false
-
   test('It returns the correct value when the phrase is a string', async function(assert) {
     await render(
       hbs`{{includes "elit" "Lorem ipsum dolor sit amet, consectetur adipiscing elit."}}`


### PR DESCRIPTION
## Changes proposed in this pull request
Inspired by this request from a different ember addon https://github.com/DockYard/ember-composable-helpers/issues/298

The `includes` helper will return true if a substring exists in a phrase, or string array.

```hbs
{{includes "some" "this is some string right here"}}
{{includes "some" (array "this" "is" "some" "string" "right" "here")}}
{{includes string phrase}}
```