### PR TITLE
Filter app tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,14 @@ module.exports = {
     return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
   },
 
+  treeForApp: function() {
+    // see: https://github.com/ember-cli/ember-cli/issues/4463
+    var tree = this._super.treeForApp.apply(this, arguments);
+    var moduleRegexp = /^helpers\//;
+
+    return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
+  },
+
   filterHelpers: function(tree, regex) {
     var whitelist = this.whitelist;
     var blacklist = this.blacklist;


### PR DESCRIPTION
Closes #294.

Implements a `treeForApp` hook to avoid shipping unwanted re-exports.

With the following config:
```js
'ember-cli-string-helpers': {
  only: ['dasherize']
}
```

**Before:**
<img width="330" alt="Screenshot 2021-01-27 at 16 56 48" src="https://user-images.githubusercontent.com/7403183/106018121-7e5e5c80-60c1-11eb-9f53-6aaca2b6dafe.png">

**After:**
<img width="336" alt="Screenshot 2021-01-27 at 16 56 05" src="https://user-images.githubusercontent.com/7403183/106018175-8a4a1e80-60c1-11eb-8f72-d0d7bc4a365e.png">
