### PR TITLE
Import htmlSafe from @ember/template (old location is deprecated)

### DIFF
--- a/addon/helpers/html-safe.js
+++ b/addon/helpers/html-safe.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe as _htmlSafe } from '@ember/string';
+import { htmlSafe as _htmlSafe } from '@ember/template';
 import createStringHelperFunction from '../-private/create-string-helper';
 
 export const htmlSafe = createStringHelperFunction(_htmlSafe);


### PR DESCRIPTION
DEPRECATION: Importing htmlSafe from '@ember/string' is deprecated. Please import htmlSafe from '@ember/template' instead. [deprecation id: ember-string.htmlsafe-ishtmlsafe] See https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe for more details.

Closes #303