### PR TITLE
Enable useYarn option to fix warning

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,6 +9,7 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then((urls) => {
     return {
+      useYarn: true,
       scenarios: [
         {
           name: 'ember-lts-2.16',


### PR DESCRIPTION
Fix the following warning during tests
```
Detected a yarn.lock file. Add `useYarn: true` to your `config/ember-try.js` configuration file if you want to use Yarn to install npm dependencies.
```