### PR TITLE
Fix deprecation warnings

### DIFF
--- a/addon/-private/create-string-helper.js
+++ b/addon/-private/create-string-helper.js
@@ -1,4 +1,4 @@
-import { isHTMLSafe } from '@ember/string';
+import { isHTMLSafe } from '@ember/template';
 
 export default function(stringFunction) {
   return function([string]) {

--- a/addon/helpers/html-safe.js
+++ b/addon/helpers/html-safe.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe as _htmlSafe } from '@ember/string';
+import { htmlSafe as _htmlSafe } from '@ember/template';
 import createStringHelperFunction from '../-private/create-string-helper';
 
 export const htmlSafe = createStringHelperFunction(_htmlSafe);

--- a/addon/helpers/humanize.js
+++ b/addon/helpers/humanize.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { isHTMLSafe } from '@ember/string';
+import { isHTMLSafe } from '@ember/template';
 
 const regex = /_+|-+/g;
 const replacement = ' ';

--- a/addon/helpers/truncate.js
+++ b/addon/helpers/truncate.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { isHTMLSafe } from '@ember/string';
+import { isHTMLSafe } from '@ember/template';
 
 export function truncate([string, characterLimit = 140, useEllipsis = true]) {
   let limit = useEllipsis ? characterLimit - 3 : characterLimit;

--- a/tests/integration/helpers/camelize-test.js
+++ b/tests/integration/helpers/camelize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{camelize}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -58,7 +58,7 @@ module('Integration | Helper | {{camelize}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('wizard', htmlSafe('harry-potter'));
 
-    await render(hbs`{{camelize wizard}}`);
+    await render(hbs`{{camelize this.wizard}}`);
 
     let expected = 'harryPotter';
 

--- a/tests/integration/helpers/capitalize-test.js
+++ b/tests/integration/helpers/capitalize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{capitalize}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -50,7 +50,7 @@ module('Integration | Helper | {{capitalize}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('greeting', htmlSafe('hi'));
 
-    await render(hbs`{{capitalize greeting}}`);
+    await render(hbs`{{capitalize this.greeting}}`);
 
     let expected = 'Hi';
 

--- a/tests/integration/helpers/classify-test.js
+++ b/tests/integration/helpers/classify-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{classify}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -50,7 +50,7 @@ module('Integration | Helper | {{classify}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('wizard', htmlSafe('harry_potter'));
 
-    await render(hbs`{{classify wizard}}`);
+    await render(hbs`{{classify this.wizard}}`);
 
     let expected = 'HarryPotter';
 

--- a/tests/integration/helpers/dasherize-test.js
+++ b/tests/integration/helpers/dasherize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{dasherize}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -50,7 +50,7 @@ module('Integration | Helper | {{dasherize}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('wizard', htmlSafe('harry_potter'));
 
-    await render(hbs`{{dasherize wizard}}`);
+    await render(hbs`{{dasherize this.wizard}}`);
 
     let expected = 'harry-potter';
 

--- a/tests/integration/helpers/html-safe-test.js
+++ b/tests/integration/helpers/html-safe-test.js
@@ -14,7 +14,7 @@ module('Integration | Helper | {{html-safe}}', function(hooks) {
 
   test('It safely renders CSS classes from a property', async function(assert) {
     this.set('classes', 'error has-error');
-    await render(hbs`<h1 class={{html-safe classes}}>Hello World</h1>`);
+    await render(hbs`<h1 class={{html-safe this.classes}}>Hello World</h1>`);
 
     assert.dom('h1').hasText('Hello World', 'it renders');
     assert.deepEqual(find('h1').getAttribute('class').split(' ').sort(), ['error', 'has-error'].sort(), 'it has the correct CSS classes');

--- a/tests/integration/helpers/humanize-test.js
+++ b/tests/integration/helpers/humanize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{humanize}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -98,7 +98,7 @@ module('Integration | Helper | {{humanize}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('sentence', htmlSafe('cHoOsE aN iTeM cOlOr'));
 
-    await render(hbs `{{humanize sentence}}`);
+    await render(hbs `{{humanize this.sentence}}`);
 
     let expected = 'Choose an item color';
 

--- a/tests/integration/helpers/lowercase-test.js
+++ b/tests/integration/helpers/lowercase-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{lowercase}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -58,7 +58,7 @@ module('Integration | Helper | {{lowercase}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('scream', htmlSafe('NOOOOOOOO'));
 
-    await render(hbs`{{lowercase scream}}`);
+    await render(hbs`{{lowercase this.scream}}`);
 
     let expected = 'noooooooo';
 

--- a/tests/integration/helpers/titleize-test.js
+++ b/tests/integration/helpers/titleize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{titleize}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -19,7 +19,7 @@ module('Integration | Helper | {{titleize}}', function(hooks) {
 
   test('It handles undefined', async function(assert) {
     await render(hbs`
-      {{titleize nostring}}
+      {{titleize this.nostring}}
     `);
 
     assert.dom('*').hasText('', 'No value');
@@ -27,7 +27,7 @@ module('Integration | Helper | {{titleize}}', function(hooks) {
 
   test('It handles null', async function(assert) {
     this.set('value', null);
-    await render(hbs`{{titleize value}}`);
+    await render(hbs`{{titleize this.value}}`);
 
     assert.dom('*').hasText('', 'No value');
   });
@@ -35,7 +35,7 @@ module('Integration | Helper | {{titleize}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('title', htmlSafe('my big fat greek wedding'));
 
-    await render(hbs`{{titleize title}}`);
+    await render(hbs`{{titleize this.title}}`);
 
     let expected = 'My Big Fat Greek Wedding';
 

--- a/tests/integration/helpers/trim-test.js
+++ b/tests/integration/helpers/trim-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{trim}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -34,7 +34,7 @@ module('Integration | Helper | {{trim}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('breakup', htmlSafe('  i need some space  '));
 
-    await render(hbs`{{trim breakup}}`);
+    await render(hbs`{{trim this.breakup}}`);
 
     let expected = 'i need some space';
 

--- a/tests/integration/helpers/truncate-test.js
+++ b/tests/integration/helpers/truncate-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{truncate}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -50,7 +50,7 @@ module('Integration | Helper | {{truncate}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('sentence', htmlSafe('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas hendrerit quam enim, in suscipit est rutrum id. Etiam vitae blandit purus, sed semper sem.'));
 
-    await render(hbs`{{truncate sentence 20}}`);
+    await render(hbs`{{truncate this.sentence 20}}`);
 
     let expected = 'Lorem ipsum dolor...';
 

--- a/tests/integration/helpers/underscore-test.js
+++ b/tests/integration/helpers/underscore-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{underscore}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -50,7 +50,7 @@ module('Integration | Helper | {{underscore}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('wizard', htmlSafe('harry-potter'));
 
-    await render(hbs`{{underscore wizard}}`);
+    await render(hbs`{{underscore this.wizard}}`);
 
     let expected = 'harry_potter';
 

--- a/tests/integration/helpers/uppercase-test.js
+++ b/tests/integration/helpers/uppercase-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 module('Integration | Helper | {{uppercase}}', function(hooks) {
   setupRenderingTest(hooks);
@@ -58,7 +58,7 @@ module('Integration | Helper | {{uppercase}}', function(hooks) {
   test('It handles a SafeString', async function(assert) {
     this.set('screamplease', htmlSafe('noooooooo'));
 
-    await render(hbs`{{uppercase screamplease}}`);
+    await render(hbs`{{uppercase this.screamplease}}`);
 
     let expected = 'NOOOOOOOO';
 

--- a/tests/integration/helpers/w-test.js
+++ b/tests/integration/helpers/w-test.js
@@ -9,7 +9,7 @@ module('Integration | Helper | {{w}}', function(hooks) {
   test('It splits the string on whitespace', async function(assert) {
     this.set('string', 'foo bar\nbaz');
 
-    await render(hbs`{{#each (w string) as |word|}}{{word}}{{/each}}`);
+    await render(hbs`{{#each (w this.string) as |word|}}{{word}}{{/each}}`);
 
     assert.dom('*').hasText('foobarbaz', 'the words are split');
   });


### PR DESCRIPTION
## Changes proposed in this pull request

* `isHTMLSafe` and `htmlSafe` now are imported from `@ember/template`
* `this-property-fallback`-deprecation is fixed