### PR TITLE
fix: remove named export from all helpers

### DIFF
--- a/src/helpers/camelize.ts
+++ b/src/helpers/camelize.ts
@@ -3,5 +3,5 @@ import { camelize as _camelize } from '@ember/string';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const camelize = createStringHelperFunction(_camelize);
+const camelize = createStringHelperFunction(_camelize);
 export default helper(camelize);

--- a/src/helpers/capitalize.ts
+++ b/src/helpers/capitalize.ts
@@ -3,5 +3,5 @@ import { capitalize as _capitalize } from '@ember/string';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const capitalize = createStringHelperFunction(_capitalize);
+const capitalize = createStringHelperFunction(_capitalize);
 export default helper(capitalize);

--- a/src/helpers/classify.ts
+++ b/src/helpers/classify.ts
@@ -3,5 +3,5 @@ import { classify as _classify } from '@ember/string';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const classify = createStringHelperFunction(_classify);
+const classify = createStringHelperFunction(_classify);
 export default helper(classify);

--- a/src/helpers/dasherize.ts
+++ b/src/helpers/dasherize.ts
@@ -3,5 +3,5 @@ import { dasherize as _dasherize } from '@ember/string';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const dasherize = createStringHelperFunction(_dasherize);
+const dasherize = createStringHelperFunction(_dasherize);
 export default helper(dasherize);

--- a/src/helpers/html-safe.ts
+++ b/src/helpers/html-safe.ts
@@ -3,5 +3,5 @@ import { htmlSafe as _htmlSafe } from '@ember/template';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const htmlSafe = createStringHelperFunction(_htmlSafe);
+const htmlSafe = createStringHelperFunction(_htmlSafe);
 export default helper(htmlSafe);

--- a/src/helpers/humanize.ts
+++ b/src/helpers/humanize.ts
@@ -7,9 +7,7 @@ const regex = /_+|-+/g;
 const replacement = ' ';
 
 // The substituted value will be contained in the result variable
-export function humanize([string]: [
-  string | SafeString | null | undefined,
-]): string {
+function humanize([string]: [string | SafeString | null | undefined]): string {
   if (isHTMLSafe(string)) {
     string = string.toString();
   }

--- a/src/helpers/lowercase.ts
+++ b/src/helpers/lowercase.ts
@@ -3,5 +3,5 @@ import { helper } from '@ember/component/helper';
 import lowercaseLib from '../utils/lowercase.ts';
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const lowercase = createStringHelperFunction(lowercaseLib);
+const lowercase = createStringHelperFunction(lowercaseLib);
 export default helper(lowercase);

--- a/src/helpers/titleize.ts
+++ b/src/helpers/titleize.ts
@@ -3,5 +3,5 @@ import { helper } from '@ember/component/helper';
 import titleizeLib from '../utils/titleize.ts';
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const titleize = createStringHelperFunction(titleizeLib);
+const titleize = createStringHelperFunction(titleizeLib);
 export default helper(titleize);

--- a/src/helpers/trim.ts
+++ b/src/helpers/trim.ts
@@ -3,5 +3,5 @@ import { helper } from '@ember/component/helper';
 import trimLib from '../utils/trim.ts';
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const trim = createStringHelperFunction(trimLib);
+const trim = createStringHelperFunction(trimLib);
 export default helper(trim);

--- a/src/helpers/truncate.ts
+++ b/src/helpers/truncate.ts
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 import { isHTMLSafe } from '@ember/template';
 
-export function truncate([string, characterLimit = 140, useEllipsis = true]: [
+function truncate([string, characterLimit = 140, useEllipsis = true]: [
   string,
   number,
   boolean,

--- a/src/helpers/underscore.ts
+++ b/src/helpers/underscore.ts
@@ -3,5 +3,5 @@ import { underscore as _underscore } from '@ember/string';
 
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const underscore = createStringHelperFunction(_underscore);
+const underscore = createStringHelperFunction(_underscore);
 export default helper(underscore);

--- a/src/helpers/uppercase.ts
+++ b/src/helpers/uppercase.ts
@@ -3,5 +3,5 @@ import { helper } from '@ember/component/helper';
 import uppercaseLib from '../utils/uppercase.ts';
 import createStringHelperFunction from '../-private/create-string-helper.ts';
 
-export const uppercase = createStringHelperFunction(uppercaseLib);
+const uppercase = createStringHelperFunction(uppercaseLib);
 export default helper(uppercase);

--- a/src/helpers/w.ts
+++ b/src/helpers/w.ts
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 import { w as toWords } from '@ember/string';
 
-export function w([...wordStrings]) {
+function w([...wordStrings]) {
   return wordStrings.map(toWords).reduce((words, moreWords) => {
     return words.concat(moreWords);
   }, []);


### PR DESCRIPTION
fixes: #399 

not sure we ever needed to export unwrapped helpers as they are unusable in ember helper format with out a wrapper